### PR TITLE
Minor fix for Induction from sum type

### DIFF
--- a/core/src/main/scala/provingground/HoTT.scala
+++ b/core/src/main/scala/provingground/HoTT.scala
@@ -2090,8 +2090,8 @@ object HoTT {
 
     def induc[W <: Term with Subs[W]](depcodom: Func[Term, Typ[W]]) = {
       val (a, b)     = (first.Var, second.Var)
-      val firstData  = (a ~>: depcodom(a)).Var
-      val secondData = (b ~>: depcodom(b)).Var
+      val firstData  = (a ~>: depcodom(incl1(a))).Var
+      val secondData = (b ~>: depcodom(incl2(b))).Var
       firstData :~>
         (secondData :~>
           (InducFn(depcodom, firstData, secondData): FuncLike[Term, W]))

--- a/mantle/src/test/scala/provingground/InductionSpecTL.scala
+++ b/mantle/src/test/scala/provingground/InductionSpecTL.scala
@@ -250,4 +250,14 @@ class InductionSpecTL extends FlatSpec {
     val step = n :~> ( m :~> (tail :~> (result :-> vconsN(succ(n))(two)(result) )  ) )
     assert(vsum(three)(iv(step)(two)(iv(step)(one)(v1))) == five)
   }
+
+  // Sum type
+  "Induction from sum type to dependent type" should "have proper type" in {
+    val B = "B" :: Type
+    val b = "b" :: B
+    val aorb = "a or b" :: PlusTyp(A, B)
+    val D = "D(_ : A + B)" :: PlusTyp(A, B) ->: Type
+    PlusTyp(A, B).induc(D) !: (a ~>: D(PlusTyp(A, B).incl1(a))) ->:
+      ((b ~>: D(PlusTyp(A, B).incl2(b))) ->: (aorb ~>: D(aorb) ))
+  }
 }


### PR DESCRIPTION
Without this fix code
```
    val A = "A" :: Type
    val B = "B" :: Type
    val D = "D(_ : A + B)" :: PlusTyp(A, B) ->: Type
    PlusTyp(A, B).induc(D)
```
didn't compile:

```
java.lang.IllegalArgumentException: requirement failed: function D(_ : A + B) : ((PlusTyp(A : 𝒰 _0,B : 𝒰 _0)) → (𝒰 _0)) with domain PlusTyp(A : 𝒰 _0,B : 𝒰 _0) cannot act on term $c : (A : 𝒰 _0) with type A : 𝒰 _0
  scala.Predef$.require(Predef.scala:293)
  provingground.HoTT$FuncLike.apply(HoTT.scala:868)
  provingground.HoTT$FuncLike.apply$(HoTT.scala:865)
  provingground.HoTT$SymbolicFunc.apply(HoTT.scala:990)
  provingground.HoTT$PlusTyp.induc(HoTT.scala:2087)
  $sess.cmd8$.<init>(cmd8.sc:1)
  $sess.cmd8$.<clinit>(cmd8.sc:-1)
```

`depcodom(a)` and `depcodom(b)` couldn't compile for a of type A and b of type B.