### PR TITLE
Automatic formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
 style = defaultWithAlign # For pretty alignment.
-maxColumn = 80          # For my wide 30" display.
+maxColumn = 120
 project.git = true

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ val ammV = "0.9.4"
 scalaOrganization in ThisBuild := "org.typelevel"
 
 scalaVersion in ThisBuild := scalaV
+scalafmtOnCompile in ThisBuild := true
+scalafmtVersion in ThisBuild := "1.0.0-RC3"
 
 classpathTypes += "maven-plugin"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 
-// addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.1")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 

--- a/wide.scalafmt
+++ b/wide.scalafmt
@@ -1,2 +1,0 @@
---style defaultWithAlign # For pretty alignment.
---maxColumn 120 


### PR DESCRIPTION
This taked a while but thanks to Paul Draper scalafmt is now fully usable for automatic formatting (including sbt files) via sbt plugin.
I let you adapt .scalafmt.conf to your prefered taste.

Then before your next push
sbt clean compile
sbt test
to have all files re-formatted with the new conf.
 
Then we will not have to worry anymore about formatting, sbt compile task will take care of it for us.