### PR TITLE
add missing , in build.sbt - otherwise sbt don't want to load root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,13 +48,13 @@ lazy val commonSettings = baseSettings ++ Seq(
     "com.lihaoyi"   %%% "sourcecode"    % "0.2.1"
   ),
   libraryDependencies ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, major)) if major <= 12 =>
-      Seq()
-    case _ =>
-      Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
-  }
-}
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, major)) if major <= 12 =>
+        Seq()
+      case _ =>
+        Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
+    }
+  },
   scalacOptions in Compile ++= Seq("-unchecked",
                                    "-deprecation",
                                    "-feature",


### PR DESCRIPTION
Clone and `sbt test` produce an error

```
/ProvingGround/build.sbt:58: error: value scalacOptions is not a member of Seq[sbt.librarymanagement.ModuleID]
possible cause: maybe a semicolon is missing before `value scalacOptions'?
  scalacOptions in Compile ++= Seq("-unchecked",
  ^
/learn/ProvingGround/build.sbt:58: error: not found: value in
  scalacOptions in Compile ++= Seq("-unchecked",
```

Adding `,`solves the problem.